### PR TITLE
Added new input parameter to restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.0
+
+- New input parameter "restart" added
+
 ### 1.3.0
 
 - fix bug that prevents multiple schedules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### 1.4.0
 
-- New input parameter "restart" added
+- New input parameter "state" added
 
 ### 1.3.0
 

--- a/timerswitch.html
+++ b/timerswitch.html
@@ -389,6 +389,7 @@
             <code>pause</code> - Pause the time schedule. You can still turn it on/off manually using the input. <br><br>
             <code>resume</code> - Start the time schedule again. If the scheduler is paused or you have set it on/off manually this will return the timer to its normal schedule.
             <br><br>
+            <code>restart</code> - Restart the time schedule. Same as restarting Node-Red. Will result on evaluating current time and passing msg attributes accordingly. <br><br>
             None of these settings are saved and a restart of Node-Red will return to the regular schedule.
             <br><br>
             If you have disabled the schedule in the configuration or not provided a schedule, the node will default to 'off' but will still accept input commands.

--- a/timerswitch.html
+++ b/timerswitch.html
@@ -389,7 +389,7 @@
             <code>pause</code> - Pause the time schedule. You can still turn it on/off manually using the input. <br><br>
             <code>resume</code> - Start the time schedule again. If the scheduler is paused or you have set it on/off manually this will return the timer to its normal schedule.
             <br><br>
-            <code>restart</code> - Restart the time schedule. Same as restarting Node-Red. Will result on evaluating current time and passing msg attributes accordingly. <br><br>
+            <code>state</code> - Same as restarting Node-Red. Will result on evaluating current time and passing msg attributes accordingly. <br><br>
             None of these settings are saved and a restart of Node-Red will return to the regular schedule.
             <br><br>
             If you have disabled the schedule in the configuration or not provided a schedule, the node will default to 'off' but will still accept input commands.

--- a/timerswitch.js
+++ b/timerswitch.js
@@ -55,7 +55,7 @@ module.exports = function(RED) {
                 node.scheduler.resume();
             } else if (command === 'restart') {
         		outputState = null;
-	        }
+	    }
 
             status();
             send(msg);

--- a/timerswitch.js
+++ b/timerswitch.js
@@ -53,7 +53,9 @@ module.exports = function(RED) {
                 node.scheduler.pause();
             } else if (command === 'resume' || command === 'run') {
                 node.scheduler.resume();
-            }
+            } else if (command === 'restart') {
+        		outputState = null;
+	        }
 
             status();
             send(msg);

--- a/timerswitch.js
+++ b/timerswitch.js
@@ -53,7 +53,7 @@ module.exports = function(RED) {
                 node.scheduler.pause();
             } else if (command === 'resume' || command === 'run') {
                 node.scheduler.resume();
-            } else if (command === 'restart') {
+            } else if (command === 'state') {
         		outputState = null;
 	    }
 


### PR DESCRIPTION
With existing input parameters it was not possible for timerswitch to restart and resend msg according to the current time. 
In my use case I needed timerswitch to restart again after some time (random timer node) and then send the message based on the current time at the time. Existing 'resume' functionality did not work for this as outputState is evaluated and that prevents sending the same message again. Here we simply set outputState=null when input is 'restart'. Updated also timerswitch.html documentation and CHANGELOG.
 
Similar needs were mentioned on https://github.com/corbosman/node-red-contrib-timerswitch/issues/8
